### PR TITLE
fix(linux): prevent Ubuntu freeze during pnpm start

### DIFF
--- a/scripts/harness/runtime-prune.mjs
+++ b/scripts/harness/runtime-prune.mjs
@@ -8,6 +8,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
+import { writeFileAtomic } from "./runtime-state.mjs";
 
 export const RUNTIME_PRUNE_POLICY_VERSION = 8;
 
@@ -279,8 +280,9 @@ require("node:child_process").execFileSync(
   { stdio: "inherit" },
 );
 `;
-  await writeFile(launcherPath, launcherSource);
-  await chmod(launcherPath, 0o755);
+  // The esbuild installer may hard-link this launcher to the canonical binary.
+  // Replace the directory entry instead of mutating the shared inode in place.
+  await writeFileAtomic(launcherPath, launcherSource, { mode: 0o755 });
   return {
     bytes: launcherInfo.size - Buffer.byteLength(launcherSource),
     files: 1,

--- a/tests/harness-runtime-prune.test.mjs
+++ b/tests/harness-runtime-prune.test.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import {
   access,
   chmod,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -382,6 +383,9 @@ test("runtime pruning replaces esbuild's duplicate binary with a launcher", asyn
     await chmod(launcher, 0o755);
     await chmod(binary, 0o755);
 
+    await rm(launcher);
+    await link(binary, launcher);
+
     const before = await inspectRuntimeArtifacts(root);
     assert.equal(before.prunable.categories.duplicateTooling.files, 1);
 
@@ -390,6 +394,7 @@ test("runtime pruning replaces esbuild's duplicate binary with a launcher", asyn
     assert.equal(report.optimized.files, 1);
     assert.ok(report.optimized.bytes > 100_000);
     assert.match(await readFile(launcher, "utf8"), /require\.resolve/u);
+    assert.deepEqual(await readFile(binary), binarySource);
     const result = spawnSync(process.execPath, [launcher, "--version"], {
       encoding: "utf8",
     });


### PR DESCRIPTION
## Summary

Fixes `pnpm start` freezing Ubuntu and, in severe cases, locking up the desktop session.

During Harness runtime staging, Minke rewrote an esbuild launcher in place. Because the launcher and native esbuild binary could be hard-linked, this corrupted the native binary and created a self-referential launcher. Starting Minke then spawned thousands of recursive processes, exhausted system memory, and triggered Ubuntu's OOM killer.

The launcher is now replaced atomically so the canonical esbuild binary and pnpm store remain intact. A regression test covers the hard-linked case.

## Testing

- `node --test tests/harness-runtime-prune.test.mjs`
- `pnpm run typecheck`
- `pnpm run harness:stage`
- `pnpm start` on Ubuntu 22.04
