### PR TITLE
fix(linux): restore missing desktop icon on Ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "minke",
   "productName": "Minke",
+  "desktopName": "minke.desktop",
   "description": "Minke desktop agent powered by DeepSeek Harness",
   "author": "lencx <lencx.me@gmail.com>",
   "license": "Apache-2.0",

--- a/tests/cross-platform-packaging.test.mjs
+++ b/tests/cross-platform-packaging.test.mjs
@@ -316,6 +316,14 @@ test("Linux makers target the packaged executable with matching case", async () 
   }
 });
 
+test("Electron uses the Linux package desktop entry", async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  );
+
+  assert.equal(manifest.desktopName, "minke.desktop");
+});
+
 for (const platform of ["darwin", "win32", "linux"]) {
   test(`packaged application layout supports ${platform}`, () => {
     const layout = packagedApplicationLayout("/project", platform, "arm64");


### PR DESCRIPTION
## Summary

- Fix the missing Minke desktop icon on Ubuntu by setting Electron's desktop name to `minke.desktop`.
- Add a regression test for the Linux desktop-entry name.

## Issue

When launching Minke with `pnpm start` on Ubuntu, the app opened but its desktop icon was not shown correctly. Electron's inferred application ID did not match Minke's desktop entry, preventing the Linux desktop shell from resolving the configured icon.

## Testing

- `node --test tests/cross-platform-packaging.test.mjs`
- `pnpm run typecheck`
